### PR TITLE
fix: updated "EVO (no WEBDL)" custom format in config template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker support! Image name is `ghcr.io/recyclarr/recyclarr`. See the [Docker] wiki page for more
   information.
 
+### Fixed
+
+- Renamed the "EVO (no WEB-DL)" custom format to "EVO (no WEBDL)" in the config template. (#77)
+
 [Docker]: https://github.com/recyclarr/recyclarr/wiki/Docker
 
 ## [2.1.2] - 2022-05-29

--- a/src/Recyclarr/config-template.yml
+++ b/src/Recyclarr/config-template.yml
@@ -48,7 +48,7 @@ radarr:
       # Do NOT use the heading names here, those do not work! These are case-insensitive.
       - names:
           - BR-DISK
-          - EVO (no WEB-DL)
+          - EVO (no WEBDL)
           - LQ
           - x265 (720/1080p)
           - 3D


### PR DESCRIPTION
The config template had the legacy custom format "EVO (no WEB-DL)", which is now "EVO (no WEBDL)".  
Fixes #77.