### PR TITLE
chore(docker): Rootless docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON Schema added to the config template YAML file.
 - `names` list under `custom_formats` in config YAML is now deprecated. Use `trash_ids` to list your
   custom formats instead.
+- Docker: The image is now rootless. The `PUID` and `PGID` environment variables are no longer used.
+  See the [Docker] wiki page for more details.
 
 ### Fixed
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,18 +22,16 @@ ENV RECYCLARR_APP_DATA=/config \
     # as needed.
     CRON_SCHEDULE="@daily" \
     # The GLOBALIZATION variable is so that we do not need libicu installed (saves us ~40MB).
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true \
-    # User can specify their own UID/GID for the 'recyclarr' user if they want
-    PUID=1000 \
-    PGID=1000
-
-VOLUME /config
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
 
 RUN set -e; \
-    apk add --no-cache busybox-suid su-exec libstdc++ tzdata; \
+    apk add --no-cache libstdc++ tzdata; \
     mkdir -p "$DOTNET_BUNDLE_EXTRACT_BASE_DIR" && chmod 777 "$DOTNET_BUNDLE_EXTRACT_BASE_DIR"
 
-COPY --chmod=755 --from=build /build/recyclarr /usr/local/bin
-COPY --chmod=755 ./scripts/prod/*.sh /
+COPY --chmod=555 --from=build /build/recyclarr /usr/local/bin
+COPY --chmod=555 ./scripts/prod/*.sh /
+
+USER 1000:1000
+VOLUME /config
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,7 @@ networks:
 services:
   recyclarr:
     image: ghcr.io/recyclarr/recyclarr
+    user: 1000:1000
     build:
       context: .
       args:

--- a/docker/scripts/prod/entrypoint.sh
+++ b/docker/scripts/prod/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+if [[ ! -z ${PUID+x} ]]; then
+    echo 'PUID is no longer supported. Use `--user` instead.'
+    exit 1
+fi
+
+if [[ ! -z ${PGID+x} ]]; then
+    echo 'PGID is no longer supported. Use `--user` instead.'
+    exit 1
+fi
+
 # If the script has any arguments, invoke the CLI instead. This allows the image to be used as a CLI
 # with something like:
 #

--- a/docker/scripts/prod/entrypoint.sh
+++ b/docker/scripts/prod/entrypoint.sh
@@ -1,14 +1,6 @@
 #!/bin/sh
 set -e
 
-userspec="$PUID:$PGID"
-
-chown "$userspec" "$RECYCLARR_APP_DATA"
-
-if [ ! -f "$RECYCLARR_APP_DATA/recyclarr.yml" ]; then
-    su-exec "$userspec" recyclarr create-config
-fi
-
 # If the script has any arguments, invoke the CLI instead. This allows the image to be used as a CLI
 # with something like:
 #
@@ -17,10 +9,10 @@ fi
 # ```
 #
 if [ "$#" -gt 0 ]; then
-    su-exec "$userspec" recyclarr "$@"
+    recyclarr "$@"
 else
     echo "Creating crontab file..."
-    echo "$CRON_SCHEDULE su-exec \"$userspec\" /cron.sh" | crontab -
+    echo "$CRON_SCHEDULE /cron.sh" | crontab -
 
     crontab -l
 


### PR DESCRIPTION
The recyclarr docker image no longer requires root.

- `PUID` and `PGID` environment variables are no longer used.
- `recyclarr.yml` is no longer created if it is missing.