### PR TITLE
chore: Add vscode editor configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-dotnettools.csharp",
+    "formulahendry.dotnet-test-explorer",
+    "editorconfig.editorconfig"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "radarr.run",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/src/Recyclarr/bin/Debug/net6.0/recyclarr",
+      "args": [
+        "radarr"
+      ],
+      "cwd": "${workspaceFolder}/src/Recyclarr/bin/Debug/net6.0/",
+      "stopAtEntry": false,
+      "console": "internalConsole"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "dotnet-test-explorer.testProjectPath": "src/**/*Tests.csproj",
+  "files.trimFinalNewlines": true,
+  "files.insertFinalNewline": true,
+  "recyclarr.runtime": "linux-musl-x64"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,45 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/src/Recyclarr/Recyclarr.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/src/Recyclarr/Recyclarr.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary",
+        "-o",
+        "${workspaceFolder}/docker/artifacts/recyclarr-${config:recyclarr.runtime}"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "test",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "test",
+        "${workspaceFolder}/src/Recyclarr.sln"
+      ],
+      "problemMatcher": "$msCompile",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds basic configuration that enables debugging and running tests in vscode. 