### PR TITLE
feat: Support secrets in config

### DIFF
--- a/src/TrashLib/AppPaths.cs
+++ b/src/TrashLib/AppPaths.cs
@@ -17,6 +17,7 @@ public class AppPaths : IAppPaths
 
     public IFileInfo ConfigPath => AppDataDirectory.File(DefaultConfigFilename);
     public IFileInfo SettingsPath => AppDataDirectory.File("settings.yml");
+    public IFileInfo SecretsPath => AppDataDirectory.File("secrets.yml");
     public IDirectoryInfo LogDirectory => AppDataDirectory.SubDirectory("logs");
     public IDirectoryInfo RepoDirectory => AppDataDirectory.SubDirectory("repo");
     public IDirectoryInfo CacheDirectory => AppDataDirectory.SubDirectory("cache");

--- a/src/TrashLib/Config/ConfigAutofacModule.cs
+++ b/src/TrashLib/Config/ConfigAutofacModule.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Autofac;
 using FluentValidation;
+using TrashLib.Config.Secrets;
 using TrashLib.Config.Services;
 using TrashLib.Config.Settings;
 using Module = Autofac.Module;
@@ -16,6 +17,7 @@ public class ConfigAutofacModule : Module
             .AsImplementedInterfaces();
 
         builder.RegisterType<SettingsProvider>().As<ISettingsProvider>().SingleInstance();
+        builder.RegisterType<SecretsProvider>().As<ISecretsProvider>().SingleInstance();
         builder.RegisterType<YamlSerializerFactory>().As<IYamlSerializerFactory>();
         builder.RegisterType<ServiceValidationMessages>().As<IServiceValidationMessages>();
     }

--- a/src/TrashLib/Config/Secrets/ISecretsProvider.cs
+++ b/src/TrashLib/Config/Secrets/ISecretsProvider.cs
@@ -1,0 +1,8 @@
+using System.Collections.Immutable;
+
+namespace TrashLib.Config.Secrets;
+
+public interface ISecretsProvider
+{
+    IImmutableDictionary<string, string> Secrets { get; }
+}

--- a/src/TrashLib/Config/Secrets/SecretsDeserializer.cs
+++ b/src/TrashLib/Config/Secrets/SecretsDeserializer.cs
@@ -1,0 +1,37 @@
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace TrashLib.Config.Secrets;
+
+public record SecretTag;
+
+public class SecretsDeserializer : INodeDeserializer
+{
+    private readonly ISecretsProvider _secrets;
+
+    public SecretsDeserializer(ISecretsProvider secrets)
+    {
+        _secrets = secrets;
+    }
+
+    public bool Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer,
+        out object? value)
+    {
+        // Only process items flagged as Secrets
+        if (expectedType != typeof(SecretTag))
+        {
+            value = null;
+            return false;
+        }
+
+        var scalar = reader.Consume<Scalar>();
+        if (!_secrets.Secrets.TryGetValue(scalar.Value, out var secretsValue))
+        {
+            throw new YamlException(scalar.Start, scalar.End, $"{scalar.Value} is not defined in secrets.yml.");
+        }
+
+        value = secretsValue;
+        return true;
+    }
+}

--- a/src/TrashLib/Config/Secrets/SecretsProvider.cs
+++ b/src/TrashLib/Config/Secrets/SecretsProvider.cs
@@ -1,0 +1,37 @@
+using System.Collections.Immutable;
+using TrashLib.Startup;
+using YamlDotNet.Serialization;
+
+namespace TrashLib.Config.Secrets;
+
+public class SecretsProvider : ISecretsProvider
+{
+    public IImmutableDictionary<string, string> Secrets => _secrets.Value;
+
+    private readonly IAppPaths _paths;
+    private readonly Lazy<IImmutableDictionary<string, string>> _secrets;
+
+    public SecretsProvider(IAppPaths paths)
+    {
+        _paths = paths;
+        _secrets = new Lazy<IImmutableDictionary<string, string>>(LoadSecretsFile);
+    }
+
+    private IImmutableDictionary<string, string> LoadSecretsFile()
+    {
+        var result = new Dictionary<string, string>();
+
+        if (_paths.SecretsPath.Exists)
+        {
+            using var stream = _paths.SecretsPath.OpenText();
+            var deserializer = new DeserializerBuilder().Build();
+            var dict = deserializer.Deserialize<Dictionary<string, string>?>(stream);
+            if (dict is not null)
+            {
+                result = dict;
+            }
+        }
+
+        return result.ToImmutableDictionary();
+    }
+}

--- a/src/TrashLib/Startup/IAppPaths.cs
+++ b/src/TrashLib/Startup/IAppPaths.cs
@@ -7,6 +7,7 @@ public interface IAppPaths
     IDirectoryInfo AppDataDirectory { get; }
     IFileInfo ConfigPath { get; }
     IFileInfo SettingsPath { get; }
+    IFileInfo SecretsPath { get; }
     IDirectoryInfo LogDirectory { get; }
     IDirectoryInfo RepoDirectory { get; }
     IDirectoryInfo CacheDirectory { get; }


### PR DESCRIPTION
Adding support for `!secrets <secret>` and secrets.yml in configuration files. This will keep sensitive variables out of configuration files and make sharing easier.