### PR TITLE
fix(git): make initial clone a shallow clone

### DIFF
--- a/src/Recyclarr.TrashLib/Repo/VersionControl/GitRepository.cs
+++ b/src/Recyclarr.TrashLib/Repo/VersionControl/GitRepository.cs
@@ -87,6 +87,9 @@ public sealed class GitRepository : IGitRepository
             args.AddRange(new[] {"-b", branch});
         }
 
+        // create a shallow clone to make initial checkout faster
+        args.AddRange(new[] {"--depth", "1"});
+
         args.AddRange(new[] {cloneUrl.ToString(), "."});
         await RunGitCmd(args);
     }


### PR DESCRIPTION
I run into a timeout because sometimes git server can be pretty slow or my vpn was limiting idk. We don't need the git history anyway