### PR TITLE
fix: Add `COMPlus_EnableDiagnostics=0` ENV to container image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,8 @@ FROM base-$TARGETARCH AS final
 ENV PATH="${PATH}:/app/recyclarr" \
     RECYCLARR_APP_DATA=/config \
     CRON_SCHEDULE="@daily" \
-    RECYCLARR_CREATE_CONFIG=false
+    RECYCLARR_CREATE_CONFIG=false \
+    COMPlus_EnableDiagnostics=0
 
 RUN set -ex; \
     apk add --no-cache bash tzdata supercronic git tini; \


### PR DESCRIPTION
This is env var is required for those that have a strict security policy on running containers. I don't see a downside to enabling this otherwise.

More info here
1. https://github.com/dotnet/docs/issues/10217
2. https://github.com/dotnet/runtime/issues/96227