### PR TITLE
feat: add support for min_format_upgrade_score

### DIFF
--- a/schemas/config/quality-profiles.json
+++ b/schemas/config/quality-profiles.json
@@ -57,6 +57,9 @@
       "min_format_score": {
         "type": "number"
       },
+      "min_format_upgrade_score": {
+        "type": "number"
+      },
       "quality_sort": {
         "enum": ["bottom", "top"],
         "default": "top"

--- a/src/Recyclarr.Cli/Pipelines/QualityProfile/PipelinePhases/QualityProfilePreviewPhase.cs
+++ b/src/Recyclarr.Cli/Pipelines/QualityProfile/PipelinePhases/QualityProfilePreviewPhase.cs
@@ -63,6 +63,11 @@ internal class QualityProfilePreviewPhase(IAnsiConsole console)
             Null(oldDto.MinFormatScore),
             Null(newDto.MinFormatScore)
         );
+        table.AddRow(
+            "Minimum Format Upgrade Score",
+            Null(oldDto.MinFormatUpgradeScore),
+            Null(newDto.MinFormatUpgradeScore)
+        );
 
         // ReSharper disable once InvertIf
         if (newDto.UpgradeAllowed is true)

--- a/src/Recyclarr.Cli/Pipelines/QualityProfile/QualityProfileStatCalculator.cs
+++ b/src/Recyclarr.Cli/Pipelines/QualityProfile/QualityProfileStatCalculator.cs
@@ -45,6 +45,11 @@ internal class QualityProfileStatCalculator(ILogger log)
         );
         Log("Cutoff Score", oldDto.CutoffFormatScore, newDto.CutoffFormatScore);
         Log("Minimum Score", oldDto.MinFormatScore, newDto.MinFormatScore);
+        Log(
+            "Minimum Upgrade Score",
+            oldDto.MinFormatUpgradeScore,
+            newDto.MinFormatUpgradeScore
+        );
 
         return;
 

--- a/src/Recyclarr.Cli/Pipelines/QualityProfile/UpdatedQualityProfile.cs
+++ b/src/Recyclarr.Cli/Pipelines/QualityProfile/UpdatedQualityProfile.cs
@@ -43,6 +43,7 @@ internal record UpdatedQualityProfile
             Name = config.Name, // Must keep this for NEW profile syncing. It will only assign if src is not null.
             UpgradeAllowed = config.UpgradeAllowed,
             MinFormatScore = config.MinFormatScore,
+            MinFormatUpgradeScore = config.MinFormatUpgradeScore,
             CutoffFormatScore = config.UpgradeUntilScore,
             FormatItems = UpdatedScores.Select(x => x.Dto with { Score = x.NewScore }).ToList(),
         };

--- a/src/Recyclarr.Core/Config/Models/ServiceConfiguration.cs
+++ b/src/Recyclarr.Core/Config/Models/ServiceConfiguration.cs
@@ -77,6 +77,7 @@ public record QualityProfileConfig
     public string? UpgradeUntilQuality { get; init; }
     public int? UpgradeUntilScore { get; init; }
     public int? MinFormatScore { get; init; }
+    public int? MinFormatUpgradeScore { get; init; }
     public string? ScoreSet { get; init; }
     public ResetUnmatchedScoresConfig ResetUnmatchedScores { get; init; } = new();
     public QualitySortAlgorithm QualitySort { get; init; }

--- a/src/Recyclarr.Core/Config/Parsing/ConfigYamlDataObjects.cs
+++ b/src/Recyclarr.Core/Config/Parsing/ConfigYamlDataObjects.cs
@@ -58,6 +58,7 @@ public record QualityProfileConfigYaml
     public ResetUnmatchedScoresConfigYaml? ResetUnmatchedScores { get; init; }
     public QualityProfileFormatUpgradeYaml? Upgrade { get; init; }
     public int? MinFormatScore { get; init; }
+    public int? MinFormatUpgradeScore { get; init; }
     public QualitySortAlgorithm? QualitySort { get; init; }
     public IReadOnlyCollection<QualityProfileQualityConfigYaml>? Qualities { get; init; }
     public string? ScoreSet { get; init; }

--- a/src/Recyclarr.Core/Config/Parsing/PostProcessing/ConfigMerging/ServiceConfigMerger.cs
+++ b/src/Recyclarr.Core/Config/Parsing/PostProcessing/ConfigMerging/ServiceConfigMerger.cs
@@ -153,6 +153,7 @@ public abstract class ServiceConfigMerger<T>
                     }
             ),
             MinFormatScore = b.MinFormatScore ?? a.MinFormatScore,
+            MinFormatUpgradeScore = b.MinFormatUpgradeScore ?? a.MinFormatUpgradeScore,
             QualitySort = b.QualitySort ?? a.QualitySort,
             ScoreSet = b.ScoreSet ?? a.ScoreSet,
             ResetUnmatchedScores = Combine(

--- a/src/Recyclarr.Core/ServarrApi/QualityProfile/QualityProfileDto.cs
+++ b/src/Recyclarr.Core/ServarrApi/QualityProfile/QualityProfileDto.cs
@@ -7,6 +7,7 @@ public record QualityProfileDto
 {
     private readonly bool? _upgradeAllowed;
     private readonly int? _minFormatScore;
+    private readonly int? _minFormatUpgradeScore;
     private int? _cutoff;
     private readonly int? _cutoffFormatScore;
     private readonly string _name = "";
@@ -36,6 +37,12 @@ public record QualityProfileDto
     {
         get => _minFormatScore;
         init => DtoUtil.SetIfNotNull(ref _minFormatScore, value);
+    }
+
+    public int? MinFormatUpgradeScore
+    {
+        get => _minFormatUpgradeScore;
+        init => DtoUtil.SetIfNotNull(ref _minFormatUpgradeScore, value);
     }
 
     public int? Cutoff

--- a/tests/Recyclarr.Cli.Tests/Pipelines/QualityProfile/Api/QualityProfileDtoTest.cs
+++ b/tests/Recyclarr.Cli.Tests/Pipelines/QualityProfile/Api/QualityProfileDtoTest.cs
@@ -29,6 +29,17 @@ internal sealed class QualityProfileDtoTest
 
     [TestCase(null, 10)]
     [TestCase(20, 20)]
+    public void Min_format_upgrade_score_set_behavior(int? value, int? expected)
+    {
+        var dto = new QualityProfileDto { MinFormatUpgradeScore = 10 };
+
+        var result = dto with { MinFormatUpgradeScore = value };
+
+        result.MinFormatUpgradeScore.Should().Be(expected);
+    }
+
+    [TestCase(null, 10)]
+    [TestCase(20, 20)]
     public void Cutoff_set_behavior(int? value, int? expected)
     {
         var dto = new QualityProfileDto { Cutoff = 10 };

--- a/tests/Recyclarr.Cli.Tests/Pipelines/QualityProfile/UpdatedQualityProfileTest.cs
+++ b/tests/Recyclarr.Cli.Tests/Pipelines/QualityProfile/UpdatedQualityProfileTest.cs
@@ -44,6 +44,7 @@ internal sealed class UpdatedQualityProfileTest
                 Id = 1,
                 Name = "dto_name",
                 MinFormatScore = 100,
+                MinFormatUpgradeScore = 100,
                 CutoffFormatScore = 200,
                 UpgradeAllowed = false,
                 Cutoff = 1,
@@ -53,6 +54,7 @@ internal sealed class UpdatedQualityProfileTest
                 {
                     Name = "config_name",
                     MinFormatScore = 110,
+                    MinFormatUpgradeScore = 110,
                     UpgradeAllowed = true,
                     UpgradeUntilScore = 220,
                 }
@@ -88,6 +90,7 @@ internal sealed class UpdatedQualityProfileTest
                     Name = "dto_name",
                     Id = 1,
                     MinFormatScore = 110,
+                    MinFormatUpgradeScore = 110,
                     CutoffFormatScore = 220,
                     UpgradeAllowed = true,
                     Items = profile.UpdatedQualities.Items,

--- a/tests/Recyclarr.Core.Tests/Config/Parsing/PostProcessing/ConfigMerging/MergeQualityProfilesTest.cs
+++ b/tests/Recyclarr.Core.Tests/Config/Parsing/PostProcessing/ConfigMerging/MergeQualityProfilesTest.cs
@@ -19,6 +19,7 @@ internal sealed class MergeQualityProfilesTest
                     Name = "e",
                     QualitySort = QualitySortAlgorithm.Top,
                     MinFormatScore = 100,
+                    MinFormatUpgradeScore = 100,
                     ScoreSet = "set1",
                     ResetUnmatchedScores = new ResetUnmatchedScoresConfigYaml
                     {
@@ -67,6 +68,7 @@ internal sealed class MergeQualityProfilesTest
                     Name = "e",
                     QualitySort = QualitySortAlgorithm.Top,
                     MinFormatScore = 100,
+                    MinFormatUpgradeScore = 100,
                     ScoreSet = "set1",
                     ResetUnmatchedScores = new ResetUnmatchedScoresConfigYaml
                     {
@@ -112,6 +114,7 @@ internal sealed class MergeQualityProfilesTest
                     Name = "e",
                     QualitySort = QualitySortAlgorithm.Top,
                     MinFormatScore = 100,
+                    MinFormatUpgradeScore = 100,
                     ScoreSet = "set1",
                     ResetUnmatchedScores = new ResetUnmatchedScoresConfigYaml
                     {
@@ -185,6 +188,7 @@ internal sealed class MergeQualityProfilesTest
                             Name = "e",
                             QualitySort = QualitySortAlgorithm.Top,
                             MinFormatScore = 100,
+                            MinFormatUpgradeScore = 100,
                             ScoreSet = "set2",
                             ResetUnmatchedScores = new ResetUnmatchedScoresConfigYaml
                             {


### PR DESCRIPTION
This adds support for `min_format_upgrade_score` which are available in both Sonarr v3 and Radarr v3 APIs.