### PR TITLE
feat(sync): add reset_before_sync option for quality definitions

### DIFF
--- a/schemas/config/quality-definition.json
+++ b/schemas/config/quality-definition.json
@@ -8,6 +8,11 @@
     "type": {
       "type": "string"
     },
+    "reset_before_sync": {
+      "type": "boolean",
+      "default": false,
+      "description": "Reset all quality definitions to installation defaults before syncing guide values."
+    },
     "preferred_ratio": {
       "type": "number",
       "default": 1.0,

--- a/src/Recyclarr.Cli/Pipelines/Plan/Components/QualitySizePlanComponent.cs
+++ b/src/Recyclarr.Cli/Pipelines/Plan/Components/QualitySizePlanComponent.cs
@@ -66,6 +66,7 @@ internal class QualitySizePlanComponent(
         {
             Type = configSizeData.Type,
             PreferredRatio = preferredRatio,
+            ResetBeforeSync = configSizeData.ResetBeforeSync,
             Qualities = plannedQualities,
         };
     }

--- a/src/Recyclarr.Cli/Pipelines/Plan/PlannedQualitySizes.cs
+++ b/src/Recyclarr.Cli/Pipelines/Plan/PlannedQualitySizes.cs
@@ -4,6 +4,7 @@ internal class PlannedQualitySizes
 {
     public required string Type { get; init; }
     public decimal? PreferredRatio { get; init; }
+    public bool ResetBeforeSync { get; init; }
     public required IReadOnlyCollection<PlannedQualityItem> Qualities { get; init; }
 }
 

--- a/src/Recyclarr.Cli/Pipelines/QualitySize/PipelinePhases/QualitySizeApiFetchPhase.cs
+++ b/src/Recyclarr.Cli/Pipelines/QualitySize/PipelinePhases/QualitySizeApiFetchPhase.cs
@@ -7,7 +7,8 @@ namespace Recyclarr.Cli.Pipelines.QualitySize.PipelinePhases;
 internal class QualitySizeApiFetchPhase(
     IQualityDefinitionApiService api,
     IQualityItemLimitFactory limitFactory,
-    IServiceConfiguration config
+    IServiceConfiguration config,
+    ILogger log
 ) : IPipelinePhase<QualitySizePipelineContext>
 {
     public async Task<PipelineFlow> Execute(
@@ -15,6 +16,12 @@ internal class QualitySizeApiFetchPhase(
         CancellationToken ct
     )
     {
+        if (context.Plan.QualitySizes.ResetBeforeSync)
+        {
+            log.Information("Resetting quality definitions to installation defaults");
+            await api.ResetQualityDefinitions(ct);
+        }
+
         context.ApiFetchOutput = await api.GetQualityDefinition(ct);
         context.Limits = await limitFactory.Create(config.ServiceType, ct);
         return PipelineFlow.Continue;

--- a/src/Recyclarr.Core/Config/Models/ServiceConfiguration.cs
+++ b/src/Recyclarr.Core/Config/Models/ServiceConfiguration.cs
@@ -75,6 +75,7 @@ public record QualityDefinitionConfig
 {
     public string Type { get; init; } = "";
     public decimal? PreferredRatio { get; set; }
+    public bool ResetBeforeSync { get; init; }
     public IReadOnlyCollection<QualityDefinitionItemConfig> Qualities { get; init; } = [];
 }
 

--- a/src/Recyclarr.Core/Config/Parsing/ConfigYamlDataObjects.cs
+++ b/src/Recyclarr.Core/Config/Parsing/ConfigYamlDataObjects.cs
@@ -56,6 +56,7 @@ public record QualitySizeConfigYaml
 {
     public string? Type { get; init; }
     public decimal? PreferredRatio { get; init; }
+    public bool? ResetBeforeSync { get; init; }
     public IReadOnlyCollection<QualitySizeItemConfigYaml>? Qualities { get; init; }
 }
 

--- a/src/Recyclarr.Core/Config/Parsing/ConfigYamlExtensions.cs
+++ b/src/Recyclarr.Core/Config/Parsing/ConfigYamlExtensions.cs
@@ -78,6 +78,7 @@ internal static class ConfigYamlExtensions
         {
             Type = yaml.Type ?? "",
             PreferredRatio = yaml.PreferredRatio,
+            ResetBeforeSync = yaml.ResetBeforeSync ?? false,
             Qualities =
                 yaml.Qualities?.Select(x => x.ToQualityDefinitionItemConfig()).ToList() ?? [],
         };

--- a/src/Recyclarr.Core/Config/Parsing/PostProcessing/ConfigMerging/ServiceConfigMerger.cs
+++ b/src/Recyclarr.Core/Config/Parsing/PostProcessing/ConfigMerging/ServiceConfigMerger.cs
@@ -41,6 +41,7 @@ public abstract class ServiceConfigMerger<T>
                     {
                         Type = b1.Type ?? a1.Type,
                         PreferredRatio = b1.PreferredRatio ?? a1.PreferredRatio,
+                        ResetBeforeSync = b1.ResetBeforeSync ?? a1.ResetBeforeSync,
                         Qualities = MergeQualitySizeItems(a1.Qualities, b1.Qualities),
                     }
             ),

--- a/src/Recyclarr.Core/ServarrApi/QualityDefinition/IQualityDefinitionApiService.cs
+++ b/src/Recyclarr.Core/ServarrApi/QualityDefinition/IQualityDefinitionApiService.cs
@@ -8,4 +8,6 @@ public interface IQualityDefinitionApiService
         IList<ServiceQualityDefinitionItem> newQuality,
         CancellationToken ct
     );
+
+    Task ResetQualityDefinitions(CancellationToken ct);
 }

--- a/src/Recyclarr.Core/ServarrApi/QualityDefinition/QualityDefinitionApiService.cs
+++ b/src/Recyclarr.Core/ServarrApi/QualityDefinition/QualityDefinitionApiService.cs
@@ -27,4 +27,11 @@ internal class QualityDefinitionApiService(IServarrRequestBuilder service)
             .PutJsonAsync(newQuality, cancellationToken: ct)
             .ReceiveJson<List<ServiceQualityDefinitionItem>>();
     }
+
+    public async Task ResetQualityDefinitions(CancellationToken ct)
+    {
+        await service
+            .Request("command")
+            .PostJsonAsync(new { name = "ResetQualityDefinitions" }, cancellationToken: ct);
+    }
 }

--- a/tests/Recyclarr.Cli.Tests/Pipelines/Plan/PlanBuilderQualitySizeTest.cs
+++ b/tests/Recyclarr.Cli.Tests/Pipelines/Plan/PlanBuilderQualitySizeTest.cs
@@ -32,6 +32,32 @@ internal sealed class PlanBuilderQualitySizeTest : PlanBuilderTestBase
     }
 
     [Test]
+    public void Build_with_reset_before_sync_propagates_to_plan()
+    {
+        SetupQualitySizeGuideData("movie", ("Bluray-1080p", 5, 100, 50));
+
+        var config = NewConfig.Radarr() with
+        {
+            QualityDefinition = new QualityDefinitionConfig
+            {
+                Type = "movie",
+                ResetBeforeSync = true,
+            },
+        };
+
+        var scopeFactory = Resolve<ConfigurationScopeFactory>();
+        using var scope = scopeFactory.Start<TestConfigurationScope>(config);
+        var sut = scope.Resolve<PlanBuilder>();
+        var storage = Resolve<SyncEventStorage>();
+
+        var plan = sut.Build();
+
+        plan.QualitySizes.Should().NotBeNull();
+        plan.QualitySizes.ResetBeforeSync.Should().BeTrue();
+        HasErrors(storage).Should().BeFalse();
+    }
+
+    [Test]
     public void Build_with_invalid_quality_type_reports_error()
     {
         var config = NewConfig.Radarr() with

--- a/tests/Recyclarr.Cli.Tests/Pipelines/QualitySize/PipelinePhases/QualitySizeApiFetchPhaseTest.cs
+++ b/tests/Recyclarr.Cli.Tests/Pipelines/QualitySize/PipelinePhases/QualitySizeApiFetchPhaseTest.cs
@@ -1,0 +1,47 @@
+using Recyclarr.Cli.Pipelines.Plan;
+using Recyclarr.Cli.Pipelines.QualitySize;
+using Recyclarr.Cli.Pipelines.QualitySize.PipelinePhases;
+using Recyclarr.Cli.Tests.Reusable;
+using Recyclarr.ServarrApi.QualityDefinition;
+
+namespace Recyclarr.Cli.Tests.Pipelines.QualitySize.PipelinePhases;
+
+internal sealed class QualitySizeApiFetchPhaseTest
+{
+    private static PipelinePlan CreatePlan(PlannedQualitySizes qualitySizes)
+    {
+        return new PipelinePlan { QualitySizes = qualitySizes };
+    }
+
+    [Test, AutoMockData]
+    public async Task Reset_called_when_reset_before_sync_is_true(
+        [Frozen] IQualityDefinitionApiService api,
+        QualitySizeApiFetchPhase sut
+    )
+    {
+        var context = new QualitySizePipelineContext
+        {
+            Plan = CreatePlan(NewPlan.Qs("test", null, true, NewPlan.QsItem("q1", 0, 100, 50))),
+        };
+
+        await sut.Execute(context, CancellationToken.None);
+
+        await api.Received(1).ResetQualityDefinitions(Arg.Any<CancellationToken>());
+    }
+
+    [Test, AutoMockData]
+    public async Task Reset_not_called_when_reset_before_sync_is_false(
+        [Frozen] IQualityDefinitionApiService api,
+        QualitySizeApiFetchPhase sut
+    )
+    {
+        var context = new QualitySizePipelineContext
+        {
+            Plan = CreatePlan(NewPlan.Qs("test", null, false, NewPlan.QsItem("q1", 0, 100, 50))),
+        };
+
+        await sut.Execute(context, CancellationToken.None);
+
+        await api.DidNotReceive().ResetQualityDefinitions(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Recyclarr.Cli.Tests/Reusable/NewPlan.cs
+++ b/tests/Recyclarr.Cli.Tests/Reusable/NewPlan.cs
@@ -92,7 +92,7 @@ internal static class NewPlan
 
     public static PlannedQualitySizes Qs(string type, params PlannedQualityItem[] qualities)
     {
-        return Qs(type, null, qualities);
+        return Qs(type, null, false, qualities);
     }
 
     public static PlannedQualitySizes Qs(
@@ -101,10 +101,21 @@ internal static class NewPlan
         params PlannedQualityItem[] qualities
     )
     {
+        return Qs(type, preferredRatio, false, qualities);
+    }
+
+    public static PlannedQualitySizes Qs(
+        string type,
+        decimal? preferredRatio,
+        bool resetBeforeSync,
+        params PlannedQualityItem[] qualities
+    )
+    {
         return new PlannedQualitySizes
         {
             Type = type,
             PreferredRatio = preferredRatio,
+            ResetBeforeSync = resetBeforeSync,
             Qualities = qualities,
         };
     }

--- a/tests/Recyclarr.Core.Tests/Config/Parsing/PostProcessing/ConfigMerging/MergeQualityDefinitionTest.cs
+++ b/tests/Recyclarr.Core.Tests/Config/Parsing/PostProcessing/ConfigMerging/MergeQualityDefinitionTest.cs
@@ -58,4 +58,56 @@ internal sealed class MergeQualityDefinitionTest
 
         result.Should().BeEquivalentTo(rightConfig);
     }
+
+    [Test]
+    public void Reset_before_sync_right_overrides_left()
+    {
+        var leftConfig = new SonarrConfigYaml
+        {
+            QualityDefinition = new QualitySizeConfigYaml
+            {
+                Type = "type1",
+                ResetBeforeSync = false,
+            },
+        };
+
+        var rightConfig = new SonarrConfigYaml
+        {
+            QualityDefinition = new QualitySizeConfigYaml
+            {
+                Type = "type1",
+                ResetBeforeSync = true,
+            },
+        };
+
+        var sut = new SonarrConfigMerger();
+
+        var result = sut.Merge(leftConfig, rightConfig);
+
+        result.QualityDefinition!.ResetBeforeSync.Should().BeTrue();
+    }
+
+    [Test]
+    public void Reset_before_sync_null_right_keeps_left()
+    {
+        var leftConfig = new SonarrConfigYaml
+        {
+            QualityDefinition = new QualitySizeConfigYaml
+            {
+                Type = "type1",
+                ResetBeforeSync = true,
+            },
+        };
+
+        var rightConfig = new SonarrConfigYaml
+        {
+            QualityDefinition = new QualitySizeConfigYaml { Type = "type1" },
+        };
+
+        var sut = new SonarrConfigMerger();
+
+        var result = sut.Merge(leftConfig, rightConfig);
+
+        result.QualityDefinition!.ResetBeforeSync.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `reset_before_sync` boolean option to the `quality_definition` YAML config block (default: `false`)
- When `true`, calls the Sonarr/Radarr `ResetQualityDefinitions` command (`POST /api/v3/command`) before fetching and applying guide values, resetting all quality definitions to installation defaults first
- No behavior change when omitted or `false`

## Example config
```yaml
quality_definition:
  type: movie
  reset_before_sync: true
```

## Contributing checklist

### C# code requirements
- [x] Zero warnings, zero analysis issues (`dotnet build` — 0 warnings, 0 errors)
- [x] Formatted with CSharpier (`dotnet csharpier format .` — no changes needed)
- [x] Conventional commit: `feat(sync): add reset_before_sync option for quality definitions`

### Unit tests
- [x] `QualitySizeApiFetchPhaseTest` — verifies `ResetQualityDefinitions()` is called when `true`, not called when `false`
- [x] `PlanBuilderQualitySizeTest` — verifies `ResetBeforeSync = true` propagates from config through to the plan
- [x] `MergeQualityDefinitionTest` — verifies right overrides left, and null right preserves left
- [x] Full test suite passes: **554 passed**, 0 failed

## Live API verification

Tested against a live **Sonarr v4.0.16.2944** instance (Debian 12, .NET 6.0.13, `main` branch).

### 1. POST — Issue the reset command

```
POST /sonarr/api/v3/command
Content-Type: application/json

{"name": "ResetQualityDefinitions"}
```

**Response (HTTP 201)** — command accepted and started:
```json
{
  "name": "ResetQualityDefinitions",
  "commandName": "Reset Quality Definitions",
  "body": {
    "resetTitles": false,
    "sendUpdatesToClient": true,
    "updateScheduledTask": true,
    "requiresDiskAccess": false,
    "isExclusive": false,
    "isLongRunning": false,
    "name": "ResetQualityDefinitions",
    "trigger": "manual",
    "suppressMessages": true
  },
  "priority": "normal",
  "status": "started",
  "result": "unknown",
  "queued": "2026-02-16T18:57:59Z",
  "started": "2026-02-16T18:57:59Z",
  "trigger": "manual",
  "stateChangeTime": "2026-02-16T18:57:59Z",
  "sendUpdatesToClient": true,
  "updateScheduledTask": true,
  "id": 706802
}
```

> `"result": "unknown"` is expected — the Sonarr command API is asynchronous. This is the initial state while the command is still running.

### 2. GET — Poll for completion

```
GET /sonarr/api/v3/command/706802
```

**Response (HTTP 200)** — command completed successfully:
```json
{
  "name": "ResetQualityDefinitions",
  "commandName": "Reset Quality Definitions",
  "priority": "normal",
  "status": "completed",
  "result": "successful",
  "queued": "2026-02-16T18:57:59Z",
  "started": "2026-02-16T18:57:59Z",
  "ended": "2026-02-16T18:57:59Z",
  "duration": "00:00:00.0222858",
  "trigger": "manual",
  "stateChangeTime": "2026-02-16T18:57:59Z",
  "sendUpdatesToClient": true,
  "updateScheduledTask": true,
  "id": 706802
}
```

The command completed in ~22ms with `"status": "completed"` and `"result": "successful"`.