### PR TITLE
feat(config): add include_when_renaming override for custom formats

### DIFF
--- a/schemas/config/custom-formats.json
+++ b/schemas/config/custom-formats.json
@@ -19,6 +19,10 @@
         "type": "integer",
         "description": "Default score applied to every profile under 'assign_scores_to' that does not define its own 'score'. Per-profile scores still override this default."
       },
+      "include_custom_format_when_renaming": {
+        "type": "boolean",
+        "description": "Override the 'Include Custom Format when Renaming' setting for every custom format listed under 'trash_ids'. When omitted, the value from TRaSH Guides is used."
+      },
       "assign_scores_to": {
         "type": ["null", "array"],
         "description": "One or more quality profiles to update with the scores from the specified custom formats.",

--- a/src/Recyclarr.Core/Config/Models/ServiceConfiguration.cs
+++ b/src/Recyclarr.Core/Config/Models/ServiceConfiguration.cs
@@ -30,6 +30,8 @@ public record CustomFormatConfig
     public ICollection<string> TrashIds { get; init; } = [];
 
     public ICollection<AssignScoresToConfig> AssignScoresTo { get; init; } = [];
+
+    public bool? IncludeCustomFormatWhenRenaming { get; init; }
 }
 
 [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]

--- a/src/Recyclarr.Core/Config/Parsing/ConfigYamlDataObjects.cs
+++ b/src/Recyclarr.Core/Config/Parsing/ConfigYamlDataObjects.cs
@@ -20,6 +20,7 @@ public record CustomFormatConfigYaml
     public IReadOnlyCollection<string>? TrashIds { get; init; }
     public int? Score { get; init; }
     public IReadOnlyCollection<QualityScoreConfigYaml>? AssignScoresTo { get; init; }
+    public bool? IncludeCustomFormatWhenRenaming { get; init; }
 }
 
 [UsedImplicitly(ImplicitUseKindFlags.Assign, ImplicitUseTargetFlags.WithMembers)]

--- a/src/Recyclarr.Core/Config/Parsing/ConfigYamlExtensions.cs
+++ b/src/Recyclarr.Core/Config/Parsing/ConfigYamlExtensions.cs
@@ -27,6 +27,7 @@ public static class ConfigYamlExtensions
             AssignScoresTo =
                 yaml.AssignScoresTo?.Select(x => x.ToAssignScoresToConfig(yaml.Score)).ToList()
                 ?? [],
+            IncludeCustomFormatWhenRenaming = yaml.IncludeCustomFormatWhenRenaming,
         };
     }
 

--- a/src/Recyclarr.Core/Config/Parsing/PostProcessing/ConfigMerging/ServiceConfigMerger.cs
+++ b/src/Recyclarr.Core/Config/Parsing/PostProcessing/ConfigMerging/ServiceConfigMerger.cs
@@ -129,10 +129,12 @@ public abstract class ServiceConfigMerger<T>
                         {
                             TrashIds = x.TrashIds,
                             AssignScoresTo = [profile with { Score = profile.Score ?? x.Score }],
+                            IncludeCustomFormatWhenRenaming = x.IncludeCustomFormatWhenRenaming,
                         })
                         : [x]
                 )
                 // Consolidate trash IDs when multiple entries target the same profile-key/score
+                // and have the same IncludeCustomFormatWhenRenaming override.
                 .GroupBy(x =>
                 {
                     var profile = x.AssignScoresTo?.SingleOrDefault();
@@ -140,7 +142,8 @@ public abstract class ServiceConfigMerger<T>
                         profileKey: GetProfileKey(profile),
                         trashId: profile?.TrashId,
                         name: profile?.Name,
-                        score: profile?.Score
+                        score: profile?.Score,
+                        includeCustomFormatWhenRenaming: x.IncludeCustomFormatWhenRenaming
                     );
                 })
                 .Select(g => new CustomFormatConfigYaml
@@ -160,6 +163,7 @@ public abstract class ServiceConfigMerger<T>
                         ]
                         // No profile key: preserve original value (null stays null, [] stays [])
                         : g.First().AssignScoresTo,
+                    IncludeCustomFormatWhenRenaming = g.Key.includeCustomFormatWhenRenaming,
                 })
                 .ToList();
         }

--- a/src/Recyclarr.Core/Pipelines/CustomFormat/ConfiguredCfEntry.cs
+++ b/src/Recyclarr.Core/Pipelines/CustomFormat/ConfiguredCfEntry.cs
@@ -7,5 +7,6 @@ internal record ConfiguredCfEntry(
     ICollection<AssignScoresToConfig> AssignScoresTo,
     string? GroupName,
     CfSource Source = CfSource.FlatConfig,
-    CfInclusionReason InclusionReason = CfInclusionReason.None
+    CfInclusionReason InclusionReason = CfInclusionReason.None,
+    bool? IncludeCustomFormatWhenRenaming = null
 );

--- a/src/Recyclarr.Core/Pipelines/CustomFormat/ConfiguredCustomFormatProvider.cs
+++ b/src/Recyclarr.Core/Pipelines/CustomFormat/ConfiguredCustomFormatProvider.cs
@@ -39,7 +39,12 @@ internal class ConfiguredCustomFormatProvider(
             );
             foreach (var trashId in cfg.TrashIds)
             {
-                yield return new ConfiguredCfEntry(trashId, resolvedScores, null);
+                yield return new ConfiguredCfEntry(
+                    trashId,
+                    resolvedScores,
+                    null,
+                    IncludeCustomFormatWhenRenaming: cfg.IncludeCustomFormatWhenRenaming
+                );
             }
         }
 

--- a/src/Recyclarr.Core/Pipelines/Plan/Components/CustomFormatPlanComponent.cs
+++ b/src/Recyclarr.Core/Pipelines/Plan/Components/CustomFormatPlanComponent.cs
@@ -40,8 +40,21 @@ internal class CustomFormatPlanComponent(
             }
 
             var first = group.First();
+
+            // First non-null override wins when a trash_id appears more than once
+            var renameOverride = group
+                .Select(x => x.IncludeCustomFormatWhenRenaming)
+                .FirstOrDefault(v => v.HasValue);
+
+            var resolvedResource = renameOverride.HasValue
+                ? resource with
+                {
+                    IncludeCustomFormatWhenRenaming = renameOverride.Value,
+                }
+                : resource;
+
             plan.AddCustomFormat(
-                new PlannedCustomFormat(resource)
+                new PlannedCustomFormat(resolvedResource)
                 {
                     AssignScoresTo = group.SelectMany(x => x.AssignScoresTo).ToList(),
                     GroupName = first.GroupName,

--- a/tests/Recyclarr.Cli.Tests/Pipelines/Plan/PlanBuilderCustomFormatTest.cs
+++ b/tests/Recyclarr.Cli.Tests/Pipelines/Plan/PlanBuilderCustomFormatTest.cs
@@ -43,6 +43,36 @@ internal sealed class PlanBuilderCustomFormatTest : PlanBuilderTestBase
     }
 
     [Test]
+    public void Build_applies_include_custom_format_when_renaming_override_to_planned_resource()
+    {
+        // Guide CF defaults to false; override to true via config
+        SetupCustomFormatGuideData(("Test CF One", "cf1"), ("Test CF Two", "cf2"));
+
+        var config = NewConfig.Radarr() with
+        {
+            CustomFormats =
+            [
+                new CustomFormatConfig { TrashIds = ["cf1"], IncludeCustomFormatWhenRenaming = true },
+                new CustomFormatConfig { TrashIds = ["cf2"] },
+            ],
+        };
+
+        var (sut, publisher) = CreatePlanBuilder(config);
+
+        var plan = sut.Build();
+
+        plan.CustomFormats.Should().HaveCount(2);
+
+        var cf1 = plan.CustomFormats.Single(x => x.Resource.TrashId == "cf1");
+        cf1.Resource.IncludeCustomFormatWhenRenaming.Should().BeTrue();
+
+        var cf2 = plan.CustomFormats.Single(x => x.Resource.TrashId == "cf2");
+        cf2.Resource.IncludeCustomFormatWhenRenaming.Should().BeFalse();
+
+        publisher.DidNotReceiveWithAnyArgs().AddError(default!);
+    }
+
+    [Test]
     public void Build_with_no_config_produces_empty_plan()
     {
         var config = NewConfig.Radarr();

--- a/tests/Recyclarr.Core.Tests/Config/Parsing/PostProcessing/ConfigMerging/MergeCustomFormatsTest.cs
+++ b/tests/Recyclarr.Core.Tests/Config/Parsing/PostProcessing/ConfigMerging/MergeCustomFormatsTest.cs
@@ -674,4 +674,57 @@ internal sealed class MergeCustomFormatsTest
                 }
             );
     }
+
+    [Test]
+    public void Include_when_renaming_override_is_preserved_through_merge()
+    {
+        var leftConfig = new SonarrConfigYaml
+        {
+            CustomFormats =
+            [
+                new CustomFormatConfigYaml
+                {
+                    TrashIds = ["cf1", "cf2"],
+                    AssignScoresTo = [new QualityScoreConfigYaml { Name = "p", Score = 100 }],
+                    IncludeCustomFormatWhenRenaming = true,
+                },
+            ],
+        };
+
+        var rightConfig = new SonarrConfigYaml
+        {
+            CustomFormats =
+            [
+                new CustomFormatConfigYaml
+                {
+                    TrashIds = ["cf3"],
+                    AssignScoresTo = [new QualityScoreConfigYaml { Name = "p", Score = 100 }],
+                    IncludeCustomFormatWhenRenaming = false,
+                },
+            ],
+        };
+
+        var sut = new SonarrConfigMerger();
+
+        var result = sut.Merge(leftConfig, rightConfig);
+
+        // Different override values keep entries separate; override is preserved on both sides.
+        CustomFormatConfigYaml[] expected =
+        [
+            new()
+            {
+                TrashIds = ["cf1", "cf2"],
+                AssignScoresTo = [new QualityScoreConfigYaml { Name = "p", Score = 100 }],
+                IncludeCustomFormatWhenRenaming = true,
+            },
+            new()
+            {
+                TrashIds = ["cf3"],
+                AssignScoresTo = [new QualityScoreConfigYaml { Name = "p", Score = 100 }],
+                IncludeCustomFormatWhenRenaming = false,
+            },
+        ];
+
+        result.CustomFormats.Should().BeEquivalentTo(expected);
+    }
 }


### PR DESCRIPTION
Adds an optional `include_custom_format_when_renaming` boolean on `custom_formats` entries that overrides the guide's `includeCustomFormatWhenRenaming` for the listed trash_ids.

```yaml
sonarr:
  main:
    custom_formats:
      - trash_ids:
          - <trash_id>
        include_custom_format_when_renaming: true
```

Name mirrors the Sonarr/Radarr field, matching the existing convention (`min_format_score`, `min_upgrade_format_score`, etc.).

For #599.

## Scope

Flat `custom_formats:` entries only. CFs entering the config exclusively through `custom_format_groups.add` or auto-discovered defaults aren't covered; users can still cover them by listing the trash_id flat with the override.

The merger preserves the field across `!include` boundaries, so split configs don't silently drop the value.

## Test plan

- [x] Unit test in `PlanBuilderCustomFormatTest`: plan component applies the override to the planned resource
- [x] Unit test in `MergeCustomFormatsTest`: override is preserved across an `!include` merge with conflicting values on each side
- [x] `dotnet csharpier check .` clean
- [x] `dotnet build -warnaserror` clean
- [x] Full unit and integration suites green
- [x] Manual sync against Sonarr 4.0.17 in Docker: setting the override applies it to the live CF; removing the override reverts to the guide value