### PR TITLE
fix(sync): rebuild oversized legacy git caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Sync: Automatic cleanup now reduces oversized resource provider caches created by older versions
+  (#907)
+
 ## [8.7.0] - 2026-07-15
 
 ### Added

--- a/src/Recyclarr.Core/Repo/RepoUpdater.cs
+++ b/src/Recyclarr.Core/Repo/RepoUpdater.cs
@@ -126,17 +126,17 @@ public class RepoUpdater(ILogger log, Func<IDirectoryInfo, IGitRepository> repoF
                 return false;
             }
 
+            if (await repo.HasRemoteReferences(token))
+            {
+                return true;
+            }
+
             log.Information(
                 "Git cache for {Name} is {SizeMb:F1} MB (limit: {LimitMb:F1} MB); running maintenance",
                 repositorySource.Name,
                 currentSize / BytesPerMegabyte,
                 limitBytes / BytesPerMegabyte
             );
-
-            if (await repo.HasRemoteReferences(token))
-            {
-                return true;
-            }
 
             await repo.RunMaintenance(token);
 

--- a/src/Recyclarr.Core/Repo/RepoUpdater.cs
+++ b/src/Recyclarr.Core/Repo/RepoUpdater.cs
@@ -8,19 +8,29 @@ namespace Recyclarr.Repo;
 public class RepoUpdater(ILogger log, Func<IDirectoryInfo, IGitRepository> repoFactory)
     : IRepoUpdater
 {
+    private const double BytesPerMegabyte = 1024.0 * 1024.0;
     private static readonly string[] ValidGitPaths = [".git/config", ".git/index", ".git/HEAD"];
 
     public async Task UpdateRepo(GitRepositorySource repositorySource, CancellationToken token)
     {
         // Assume failure until it succeeds, to simplify the catch handlers.
         var succeeded = false;
+        var rebuildLegacyCache = false;
 
         // Retry only once if there's a failure. This gives us an opportunity to delete the git repository and start
         // fresh.
         try
         {
-            await CheckoutAndUpdateRepo(repositorySource, token);
-            succeeded = true;
+            rebuildLegacyCache = await CheckoutAndUpdateRepo(repositorySource, token);
+            succeeded = !rebuildLegacyCache;
+
+            if (rebuildLegacyCache)
+            {
+                log.Information(
+                    "Rebuilding legacy git cache for {Name} because stale references prevent storage cleanup",
+                    repositorySource.Name
+                );
+            }
         }
         catch (GitCmdException e)
         {
@@ -33,13 +43,18 @@ public class RepoUpdater(ILogger log, Func<IDirectoryInfo, IGitRepository> repoF
 
         if (!succeeded)
         {
-            log.Warning("Deleting local git repo and retrying git operation due to error");
+            if (!rebuildLegacyCache)
+            {
+                log.Warning("Deleting local git repo and retrying git operation due to error");
+            }
+
             repositorySource.Path.DeleteReadOnlyDirectory();
-            await CheckoutAndUpdateRepo(repositorySource, token);
+            _ = await CheckoutAndUpdateRepo(repositorySource, token);
         }
     }
 
-    private async Task CheckoutAndUpdateRepo(
+    // Returns whether the cache must be rebuilt to remove legacy Git references.
+    private async Task<bool> CheckoutAndUpdateRepo(
         GitRepositorySource repositorySource,
         CancellationToken token
     )
@@ -77,7 +92,7 @@ public class RepoUpdater(ILogger log, Func<IDirectoryInfo, IGitRepository> repoF
         }
 
         await repo.ResetHard("FETCH_HEAD", token);
-        await MaybeRunMaintenanceAsync(repo, repositorySource, token);
+        return await MaybeRunMaintenanceAsync(repo, repositorySource, token);
     }
 
     [SuppressMessage(
@@ -85,7 +100,7 @@ public class RepoUpdater(ILogger log, Func<IDirectoryInfo, IGitRepository> repoF
         "CA1031:Do not catch general exception types",
         Justification = "Maintenance is best-effort; any failure must not propagate to fail the sync."
     )]
-    private async Task MaybeRunMaintenanceAsync(
+    private async Task<bool> MaybeRunMaintenanceAsync(
         IGitRepository repo,
         GitRepositorySource repositorySource,
         CancellationToken token
@@ -94,13 +109,13 @@ public class RepoUpdater(ILogger log, Func<IDirectoryInfo, IGitRepository> repoF
         var limitBytes = repositorySource.CacheLimit.Bytes;
         if (limitBytes <= 0)
         {
-            return;
+            return false;
         }
 
         var gitDir = repositorySource.Path.SubDirectory(".git");
         if (!gitDir.Exists)
         {
-            return;
+            return false;
         }
 
         try
@@ -108,17 +123,40 @@ public class RepoUpdater(ILogger log, Func<IDirectoryInfo, IGitRepository> repoF
             var currentSize = gitDir.DirectorySize();
             if (currentSize <= limitBytes)
             {
-                return;
+                return false;
             }
 
             log.Information(
                 "Git cache for {Name} is {SizeMb:F1} MB (limit: {LimitMb:F1} MB); running maintenance",
                 repositorySource.Name,
-                currentSize / (1024.0 * 1024.0),
-                limitBytes / (1024.0 * 1024.0)
+                currentSize / BytesPerMegabyte,
+                limitBytes / BytesPerMegabyte
             );
 
+            if (await repo.HasRemoteReferences(token))
+            {
+                return true;
+            }
+
             await repo.RunMaintenance(token);
+
+            var finalSize = gitDir.DirectorySize();
+            log.Information(
+                "Git cache maintenance for {Name} completed: {PreviousSizeMb:F1} MB -> {FinalSizeMb:F1} MB",
+                repositorySource.Name,
+                currentSize / BytesPerMegabyte,
+                finalSize / BytesPerMegabyte
+            );
+
+            if (finalSize > limitBytes)
+            {
+                log.Warning(
+                    "Git cache for {Name} remains above the cleanup threshold: {SizeMb:F1} MB (limit: {LimitMb:F1} MB)",
+                    repositorySource.Name,
+                    finalSize / BytesPerMegabyte,
+                    limitBytes / BytesPerMegabyte
+                );
+            }
         }
         catch (OperationCanceledException)
         {
@@ -128,6 +166,8 @@ public class RepoUpdater(ILogger log, Func<IDirectoryInfo, IGitRepository> repoF
         {
             log.Warning(e, "Git cache maintenance failed for {Name}", repositorySource.Name);
         }
+
+        return false;
     }
 
     private static void ValidateGitDirectory(IDirectoryInfo repoPath)

--- a/src/Recyclarr.Core/VersionControl/GitRepository.cs
+++ b/src/Recyclarr.Core/VersionControl/GitRepository.cs
@@ -107,6 +107,15 @@ public sealed class GitRepository(ILogger log, IGitPath gitPath, IDirectoryInfo 
         await RunGitCmd(token, "reset", "--hard", toBranchOrSha1);
     }
 
+    public async Task<bool> HasRemoteReferences(CancellationToken token)
+    {
+        var refs = await RunGitCmdCore(
+            ["for-each-ref", "--format=%(refname)", "refs/remotes"],
+            token
+        );
+        return refs.Length > 0;
+    }
+
     public async Task RunMaintenance(CancellationToken token)
     {
         // Trim .git/shallow to only the current HEAD so prior depth-1 fetches don't keep old

--- a/src/Recyclarr.Core/VersionControl/IGitRepository.cs
+++ b/src/Recyclarr.Core/VersionControl/IGitRepository.cs
@@ -13,5 +13,6 @@ public interface IGitRepository : IDisposable
 
     Task ResetHard(string toBranchOrSha1, CancellationToken token);
     Task Status(CancellationToken token);
+    Task<bool> HasRemoteReferences(CancellationToken token);
     Task RunMaintenance(CancellationToken token);
 }

--- a/tests/Recyclarr.Core.Tests/Repo/RepoUpdaterIntegrationTest.cs
+++ b/tests/Recyclarr.Core.Tests/Repo/RepoUpdaterIntegrationTest.cs
@@ -1,5 +1,6 @@
-using System.Diagnostics;
 using System.IO.Abstractions;
+using System.Text;
+using CliWrap;
 using Recyclarr.Common;
 using Recyclarr.Common.Extensions;
 using Recyclarr.Repo;
@@ -133,34 +134,21 @@ internal sealed class RepoUpdaterIntegrationTest
         CancellationToken ct
     )
     {
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = "git",
-            WorkingDirectory = repository.FullName,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
+        var output = new StringBuilder();
+        var error = new StringBuilder();
 
-        foreach (var argument in arguments)
-        {
-            startInfo.ArgumentList.Add(argument);
-        }
-
-        using var process = new Process { StartInfo = startInfo };
-        if (!process.Start())
-        {
-            throw new InvalidOperationException("Failed to start git");
-        }
-
-        var outputTask = process.StandardOutput.ReadToEndAsync(ct);
-        var errorTask = process.StandardError.ReadToEndAsync(ct);
-        await process.WaitForExitAsync(ct);
+        var result = await Cli.Wrap("git")
+            .WithArguments(arguments)
+            .WithValidation(CommandResultValidation.None)
+            .WithWorkingDirectory(repository.FullName)
+            .WithStandardOutputPipe(PipeTarget.ToStringBuilder(output))
+            .WithStandardErrorPipe(PipeTarget.ToStringBuilder(error))
+            .ExecuteAsync(ct);
 
         return new GitCommandResult(
-            process.ExitCode,
-            (await outputTask).Trim(),
-            (await errorTask).Trim()
+            result.ExitCode,
+            output.ToString().Trim(),
+            error.ToString().Trim()
         );
     }
 

--- a/tests/Recyclarr.Core.Tests/Repo/RepoUpdaterIntegrationTest.cs
+++ b/tests/Recyclarr.Core.Tests/Repo/RepoUpdaterIntegrationTest.cs
@@ -1,0 +1,168 @@
+using System.Diagnostics;
+using System.IO.Abstractions;
+using Recyclarr.Common;
+using Recyclarr.Common.Extensions;
+using Recyclarr.Repo;
+using Recyclarr.VersionControl;
+
+namespace Recyclarr.Core.Tests.Repo;
+
+internal sealed class RepoUpdaterIntegrationTest
+{
+    [Test]
+    public async Task Oversized_legacy_cache_is_rebuilt_without_stale_remote_history()
+    {
+        var fs = new FileSystem();
+        var root = fs.DirectoryInfo.New(
+            Path.Join(Path.GetTempPath(), $"recyclarr-git-test-{Guid.NewGuid():N}")
+        );
+        root.Create();
+
+        try
+        {
+            var ct = CancellationToken.None;
+            var sourcePath = root.SubDirectory("source");
+            sourcePath.Create();
+            await RunGit(sourcePath, ["init", "--initial-branch=master"], ct);
+
+            await sourcePath.FileSystem.File.WriteAllTextAsync(
+                sourcePath.File("guide.txt").FullName,
+                "legacy",
+                ct
+            );
+            await CommitAll(sourcePath, "legacy", ct);
+            var legacyCommit = await RunGit(sourcePath, ["rev-parse", "HEAD"], ct);
+            await RunGit(sourcePath, ["branch", "legacy"], ct);
+
+            await sourcePath.FileSystem.File.WriteAllTextAsync(
+                sourcePath.File("guide.txt").FullName,
+                "current",
+                ct
+            );
+            await CommitAll(sourcePath, "current", ct);
+            var expectedHead = await RunGit(sourcePath, ["rev-parse", "HEAD"], ct);
+
+            var cachePath = root.SubDirectory("cache");
+            await RunGit(root, ["clone", sourcePath.FullName, cachePath.FullName], ct);
+
+            var gitPath = Substitute.For<IGitPath>();
+            gitPath.Path.Returns("git");
+            var log = Substitute.For<ILogger>();
+            var updater = new RepoUpdater(log, path => new GitRepository(log, gitPath, path));
+            var source = new GitRepositorySource
+            {
+                Name = "test",
+                CloneUrl = new Uri(sourcePath.FullName),
+                References = ["master"],
+                Path = cachePath,
+                CacheLimit = DataSize.FromKilobytes(1),
+            };
+
+            await updater.UpdateRepo(source, ct);
+
+            var remoteRefs = await RunGit(
+                cachePath,
+                ["for-each-ref", "--format=%(refname)", "refs/remotes"],
+                ct
+            );
+            var actualHead = await RunGit(cachePath, ["rev-parse", "HEAD"], ct);
+            var legacyCommitExists = await GitObjectExists(cachePath, legacyCommit, ct);
+
+            remoteRefs.Should().BeEmpty();
+            actualHead.Should().Be(expectedHead);
+            legacyCommitExists.Should().BeFalse();
+        }
+        finally
+        {
+            root.DeleteReadOnlyDirectory();
+        }
+    }
+
+    private static async Task CommitAll(
+        IDirectoryInfo repository,
+        string message,
+        CancellationToken ct
+    )
+    {
+        await RunGit(repository, ["add", "."], ct);
+        await RunGit(
+            repository,
+            [
+                "-c",
+                "user.name=Recyclarr Tests",
+                "-c",
+                "user.email=recyclarr@example.com",
+                "commit",
+                "-m",
+                message,
+            ],
+            ct
+        );
+    }
+
+    private static async Task<bool> GitObjectExists(
+        IDirectoryInfo repository,
+        string objectId,
+        CancellationToken ct
+    )
+    {
+        var result = await ExecuteGit(repository, ["cat-file", "-e", objectId], ct);
+        return result.ExitCode == 0;
+    }
+
+    private static async Task<string> RunGit(
+        IDirectoryInfo repository,
+        IReadOnlyCollection<string> arguments,
+        CancellationToken ct
+    )
+    {
+        var result = await ExecuteGit(repository, arguments, ct);
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"git {string.Join(' ', arguments)} failed with exit code {result.ExitCode}: {result.Error}"
+            );
+        }
+
+        return result.Output;
+    }
+
+    private static async Task<GitCommandResult> ExecuteGit(
+        IDirectoryInfo repository,
+        IReadOnlyCollection<string> arguments,
+        CancellationToken ct
+    )
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = repository.FullName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = new Process { StartInfo = startInfo };
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Failed to start git");
+        }
+
+        var outputTask = process.StandardOutput.ReadToEndAsync(ct);
+        var errorTask = process.StandardError.ReadToEndAsync(ct);
+        await process.WaitForExitAsync(ct);
+
+        return new GitCommandResult(
+            process.ExitCode,
+            (await outputTask).Trim(),
+            (await errorTask).Trim()
+        );
+    }
+
+    private sealed record GitCommandResult(int ExitCode, string Output, string Error);
+}

--- a/tests/Recyclarr.Core.Tests/Repo/RepoUpdaterTest.cs
+++ b/tests/Recyclarr.Core.Tests/Repo/RepoUpdaterTest.cs
@@ -15,6 +15,7 @@ internal sealed class RepoUpdaterTest
     {
         // 200MB .git dir with 100MB limit
         var repoPath = fs.WithGitDir(200 * 1024 * 1024);
+        repo.HasRemoteReferences(CancellationToken.None).ReturnsForAnyArgs(false);
 
         var source = new GitRepositorySource
         {
@@ -30,6 +31,33 @@ internal sealed class RepoUpdaterTest
         await sut.UpdateRepo(source, CancellationToken.None);
 
         await repo.ReceivedWithAnyArgs().RunMaintenance(default);
+    }
+
+    [Test, AutoMockData]
+    public async Task Oversized_legacy_cache_is_reinitialized(
+        [Frozen] IGitRepository repo,
+        [Frozen] MockFileSystem fs
+    )
+    {
+        var repoPath = fs.WithGitDir(200 * 1024 * 1024);
+        repo.HasRemoteReferences(CancellationToken.None).ReturnsForAnyArgs(true);
+
+        var source = new GitRepositorySource
+        {
+            Name = "test",
+            CloneUrl = new Uri("https://example.com/repo.git"),
+            References = ["master"],
+            Path = repoPath,
+            CacheLimit = DataSize.FromMegabytes(100),
+        };
+
+        var sut = new RepoUpdater(Substitute.For<ILogger>(), _ => repo);
+
+        await sut.UpdateRepo(source, CancellationToken.None);
+
+        await repo.ReceivedWithAnyArgs().HasRemoteReferences(default);
+        await repo.ReceivedWithAnyArgs().Init(default);
+        await repo.DidNotReceiveWithAnyArgs().RunMaintenance(default);
     }
 
     [Test, AutoMockData]
@@ -89,8 +117,8 @@ internal sealed class RepoUpdaterTest
     )
     {
         var repoPath = fs.WithGitDir(200 * 1024 * 1024);
-
-        repo.RunMaintenance(default!)
+        repo.HasRemoteReferences(CancellationToken.None).ReturnsForAnyArgs(false);
+        repo.RunMaintenance(CancellationToken.None)
             .ReturnsForAnyArgs(_ => throw new GitCmdException(1, "gc failed"));
 
         var source = new GitRepositorySource


### PR DESCRIPTION
## Related issue

Closes #907

## What this does

- detects oversized provider caches whose legacy remote refs would keep old history reachable
- rebuilds those disposable caches through the current depth-1 fetch path
- retains normal Git maintenance for current-style caches
- logs the size before and after maintenance and warns when it remains above the threshold
- adds unit coverage and a real local-Git regression test proving stale refs and commit objects are removed

## Verification

- `dotnet test Recyclarr.slnx -v q`
- the integration test creates a legacy clone with an extra remote branch, runs `RepoUpdater`, and verifies the rebuilt cache contains the expected HEAD without remote refs or the stale commit object

## Checklist

- [ ] Design was discussed and approved in the linked issue before this PR was written
- [x] I can explain every change in this PR and will engage with review questions
- [x] All tests pass (`dotnet test -v q`)
- [x] Pre-commit checks pass (`git add <files> && pre-commit run`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic cleanup for oversized resource provider caches created by older versions.
  * Legacy/oversized caches are now rebuilt when stale remote references are detected.
  * Cache maintenance issues no longer interrupt repository synchronization (best-effort handling).
  * Added safeguards to avoid cache maintenance when caching is disabled or Git metadata is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->